### PR TITLE
Use named image & context in compose, tweak Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
-RUN pip install --upgrade pip
 
+COPY ./app /app
+COPY requirements.txt /app/requirements.txt
 WORKDIR /app
 
 # Install Packages
-COPY requirements.txt ./requirements.txt
-RUN pip install -r requirements.txt
-
-COPY . /app
-
-COPY entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh
-ENTRYPOINT ["./entrypoint.sh"]
-#EXPOSE 8009
+RUN pip install --upgrade pip && pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.9"
 
 services:
   api:
-    build: .
+    image: gpspake/fastapi-project:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
     command: uvicorn app.main:app --reload --port 8009
     volumes:
       - .:/app


### PR DESCRIPTION
With these changes, it seems to run on my machine.

```
docker build -t gpspake/fastapi-project:latest .
...

docker run -d --name mycontainer -p 80:80 docker.io/gpspake/fastapi-project:latest
```
![image](https://user-images.githubusercontent.com/967362/116785858-5df7c280-aa61-11eb-9c6f-3445b6389765.png)
